### PR TITLE
Use rustls 0.19, fix lint check name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["X509", "ASN1", "cryptography", "pki"]
 ring = { version = "0.16.15", default-features = false }
 untrusted = "0.7.1"
 w = { package = "webpki", version = "0.21.3", optional = true, default-features = false }
-r = { package = "rustls", version = "0.18.0", optional = true }
+r = { package = "rustls", version = "0.19", optional = true }
 
 [dev-dependencies]
 chrono = "0.4.13"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@
 #![forbid(
     unconditional_recursion,
     unsafe_code,
-    intra_doc_link_resolution_failure,
+    broken_intra_doc_links,
     while_true,
     elided_lifetimes_in_paths
 )]


### PR DESCRIPTION
I'm trying to get this working with some example code from Rustls and had to bump the version. Also fixed a lint check name that prevented compiling.